### PR TITLE
ADR-2009 fix flaky tests in RichJsValueSpec

### DIFF
--- a/test/models/RichJsValueSpec.scala
+++ b/test/models/RichJsValueSpec.scala
@@ -37,6 +37,8 @@ class RichJsValueSpec
   val max                           = 10
   val nonEmptyAlphaStr: Gen[String] = Gen.alphaStr.suchThat(_.nonEmpty)
 
+  val nonEmptyAlphaStrRetryUntil: Gen[String] = Gen.alphaStr.retryUntil(_.nonEmpty)
+
   def buildJsObj[B](keys: Seq[String], values: Seq[B])(implicit writes: Writes[B]): JsObject =
     keys.zip(values).foldLeft(JsObject.empty) { case (acc, (key, value)) =>
       acc + (key -> Json.toJson[B](value))
@@ -259,9 +261,9 @@ class RichJsValueSpec
     "must remove a value given a keyPathNode and return the new object" in {
 
       val gen = for {
-        keys          <- Gen.listOf(nonEmptyAlphaStr)
+        keys          <- Gen.listOf(nonEmptyAlphaStr).map(_.distinct)
         values        <- Gen.listOf(nonEmptyAlphaStr)
-        keyToRemove   <- nonEmptyAlphaStr
+        keyToRemove   <- nonEmptyAlphaStr.suchThat(k => !keys.contains(k))
         valueToRemove <- nonEmptyAlphaStr
       } yield (keys, values, keyToRemove, valueToRemove)
 


### PR DESCRIPTION
This PR is for the ticket [ADR-2009](https://jira.tools.tax.service.gov.uk/browse/ADR-2009) Fix flaky RichJsValueSpec test

The reason for "must return an error given a keyPathNode for an array" test to fail is because sometimes the sample returned none. Using retryUntil, rather than suchThat here fixed the issue since the generated value was never none.

The second flaky test "must remove a value given a keyPathNode and return the new object" occurred much more infrequently, however was caused, I believe, by the key chosen to be added already being part of the list, causing an error when processing. This was fixed by forcing the key to be added not already being a key in the JSObject.